### PR TITLE
The endpoint accepts Attribution Reporting and Private Click Measurement

### DIFF
--- a/ingestly.vcl
+++ b/ingestly.vcl
@@ -11,17 +11,19 @@ table apikeys {
 sub vcl_recv {
 #FASTLY recv
   if(table.lookup(apikeys, subfield(req.url.qs, "key", "&")) != "true"){
-    # Invalid API Key (if you configure Fastly to use only for Ingestly, use the below.)
-    # error 401 "Unauthorized";
+    if(req.url ~ "^\.well-known\/attribution-reporting\/.*" || req.url ~ "^\.well-known\/private-click-measurement\/.*"){
+      # Attribution Reporting & Private Click Measurement
+      error 200 "OK";
+    }else{
+      # Invalid API Key (if you configure Fastly to use only for Ingestly, use the below.)
+      # error 401 "Unauthorized";
+    }
   }else{
     if(req.url ~ "^/ingestly-ingest/(.*?)/\?.*" || req.url ~ "^/ingestly-consent/(.*?)/\?.*" || req.url ~ "^/ingestly-bulk/(.*?)/\?.*"){
       # Valid Ingestion
       error 204 "No Content";
     }else if(req.url ~ "^/ingestly-sync/(.*?)/\?.*"){
       # Valid Sync (< 1.0.0)
-      error 200 "OK";
-    }else if(req.url ~ "^\.well-known\/attribution-reporting\/.*" || req.url ~ "^\.well-known\/private-click-measurement\/.*"){
-      # Attribution Reporting & Private Click Measurement
       error 200 "OK";
     }else{
       # Invalid Request (if you configure Fastly to use only for Ingestly, use the below.)

--- a/ingestly.vcl
+++ b/ingestly.vcl
@@ -11,7 +11,7 @@ table apikeys {
 sub vcl_recv {
 #FASTLY recv
   if(table.lookup(apikeys, subfield(req.url.qs, "key", "&")) != "true"){
-    if(req.url ~ "^\.well-known\/attribution-reporting\/.*" || req.url ~ "^\.well-known\/private-click-measurement\/.*"){
+    if(req.url ~ "^/\.well-known/(attribution-reporting|private-click-measurement)/.*"){
       # Attribution Reporting & Private Click Measurement
       error 200 "OK";
     }else{
@@ -116,6 +116,9 @@ sub vcl_error {
                               + "; Path=/; SameSite=Lax; Secure;";
     }
 
+    return (deliver);
+  }elseif(req.url ~ "^/\.well-known/(attribution-reporting|private-click-measurement)/.*"){
+    # Attribution Reporting & Private Click Measurement
     return (deliver);
   }
 }

--- a/ingestly.vcl
+++ b/ingestly.vcl
@@ -20,6 +20,9 @@ sub vcl_recv {
     }else if(req.url ~ "^/ingestly-sync/(.*?)/\?.*"){
       # Valid Sync (< 1.0.0)
       error 200 "OK";
+    }else if(req.url ~ "^\.well-known\/attribution-reporting\/.*" || req.url ~ "^\.well-known\/private-click-measurement\/.*"){
+      # Attribution Reporting & Private Click Measurement
+      error 200 "OK";
     }else{
       # Invalid Request (if you configure Fastly to use only for Ingestly, use the below.)
       # error 400 "Bad Request";


### PR DESCRIPTION
Google uses a path starting with `.well-known/attribution-reporting/` for Attribution Reporting, Apple uses a path starting with `.well-known/private-click-measurement/` for Private Click Measurement.
The endpoint should receive requests to both path and should return `200`.